### PR TITLE
[feature] 添加二维码显示兼容模式，确保任何终端都能显示二维码

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,6 +208,7 @@ learn_unittest.py
 *.bat
 *.zip
 *.code-workspace
+*.bak
 # exclude
 !test.json
 !build.bat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bili_live_tool"
-version = "0.4.5"
+version = "0.4.6"
 description = "a simple tool to start or stop bilibili live and get stream code."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/core/auth.py
+++ b/src/core/auth.py
@@ -10,10 +10,8 @@ from dataclasses import dataclass
 from enum import Enum, auto
 
 import requests
-from qrcode import QRCode
 
-from ..utils.constants import ApiEndpoints, QR_IMG, USER_AGENT
-from ..utils.cleanup import cleanup_qr_files
+from ..utils.constants import ApiEndpoints, USER_AGENT
 from .config import ConfigManager
 
 logger = logging.getLogger(__name__)
@@ -76,23 +74,13 @@ class AuthManager:
             qr_url = data["data"]["url"]
             qr_key = data["data"]["qrcode_key"]
 
-            # 生成二维码图片
-            qr = QRCode()
-            qr.add_data(qr_url)
-            qr.make(fit=True)
-            qr_image = qr.make_image()
-            with open(QR_IMG, "wb") as f:
-                qr_image.save(f)
-
-            logger.info(f"二维码已生成: {QR_IMG}")
+            logger.info("二维码已生成")
             return qr_url, qr_key
 
         except requests.RequestException as e:
-            cleanup_qr_files()
             logger.error(f"网络请求失败: {e}")
             raise Exception(f"网络请求失败: {e}")
         except Exception as e:
-            cleanup_qr_files()
             logger.error(f"生成二维码失败: {e}")
             raise
 
@@ -123,7 +111,6 @@ class AuthManager:
                 cookies = response.cookies.get_dict()
                 refresh_token = data["data"].get("refresh_token", "")
                 logger.info("二维码登录成功")
-                cleanup_qr_files()
                 return QRLoginResult(
                     status=LoginStatus.SUCCESS,
                     cookies=cookies,
@@ -197,19 +184,16 @@ class AuthManager:
                     # 保存登录信息
                     if result.cookies is None:
                         notify("登录失败：未获取到凭证")
-                        cleanup_qr_files()
                         return False
                     self.config_manager.update_cookies(
                         result.cookies,
                         result.refresh_token or "",
                     )
                     notify("登录成功！")
-                    cleanup_qr_files()
                     return True
 
                 if result.status == LoginStatus.EXPIRED:
                     notify("二维码已过期，请重试")
-                    cleanup_qr_files()
                     return False
 
                 if result.status == LoginStatus.SCANNED and not scanned_notified:
@@ -218,7 +202,6 @@ class AuthManager:
 
                 if result.status == LoginStatus.ERROR:
                     notify(f"登录出错: {result.message}")
-                    cleanup_qr_files()
                     return False
 
                 sleep(1)

--- a/src/ui/screen/qr_display_screen.py
+++ b/src/ui/screen/qr_display_screen.py
@@ -55,8 +55,12 @@ class QRDisplayScreen(ModalScreen):
             qr_content = self.query_one("#qr-content", Static)
             too_small_msg = self.query_one("#qr-too-small", Static)
 
-            min_width = self.qr_size + 11
-            min_height = self.qr_size // 2 + 9
+            if getattr(self, "_compat", False):
+                min_width = self.qr_size + 14
+                min_height = self.qr_size // 2 + 11
+            else:
+                min_width = self.qr_size + 11
+                min_height = self.qr_size // 2 + 9
 
             if container_width < min_width or container_height < min_height:
                 qr_content.styles.display = "none"
@@ -83,6 +87,7 @@ class QRDisplayScreen(ModalScreen):
             (True, True): "█",
         }
         compat = not is_modern_terminal()
+        self._compat = compat
         qr_data = []
         try:
             qr = qrcode.QRCode(

--- a/src/ui/screen/qr_display_screen.py
+++ b/src/ui/screen/qr_display_screen.py
@@ -56,10 +56,10 @@ class QRDisplayScreen(ModalScreen):
             too_small_msg = self.query_one("#qr-too-small", Static)
 
             if getattr(self, "_compat", False):
-                min_width = self.qr_size + 14
+                min_width = self.qr_size + 16
                 min_height = self.qr_size // 2 + 11
             else:
-                min_width = self.qr_size + 11
+                min_width = self.qr_size + 12
                 min_height = self.qr_size // 2 + 9
 
             if container_width < min_width or container_height < min_height:

--- a/src/ui/screen/qr_display_screen.py
+++ b/src/ui/screen/qr_display_screen.py
@@ -1,7 +1,8 @@
-"""高精度二维码显示组件
+"""高精度二维码显示组件.
 
-使用2x2字符格子表示二维码模块，提高扫描成功率。
-显示在窗口顶部，支持登录和人脸识别两种场景。
+支持两种渲染模式:
+  现代终端 --- 使用半块字符压缩, 二维码接近正方形
+  兼容终端 --- 使用全块字符, 逐行渲染, 适合 cmd.exe 等老式终端
 """
 
 from textual.screen import ModalScreen
@@ -12,6 +13,7 @@ from textual.binding import Binding
 import qrcode
 
 from ...utils.constants import KeyBindings
+from ...utils.lib import is_modern_terminal
 
 
 class QRDisplayScreen(ModalScreen):
@@ -74,12 +76,13 @@ class QRDisplayScreen(ModalScreen):
             self.query_one("#qr-content", Static).update(f"[二维码生成失败: {e}]")
 
     def _generate_qr_data(self) -> None:
-        CHARS = {
+        _modern_chars = {
             (False, False): " ",
             (True, False): "▀",
             (False, True): "▄",
             (True, True): "█",
         }
+        compat = not is_modern_terminal()
         qr_data = []
         try:
             qr = qrcode.QRCode(
@@ -92,21 +95,31 @@ class QRDisplayScreen(ModalScreen):
             qr.make(fit=False)
             matrix = qr.get_matrix()
             size = len(matrix)
-            for row in range(0, size, 2):
-                qr_line = ""
-                for line in range(size):
-                    qr_line += CHARS[
-                        (
-                            matrix[row][line],
-                            matrix[row + 1][line] if row + 1 < size else False,
-                        )
-                    ]
-                qr_data.append(qr_line)
-            self.qr_size = len(qr_data) * 2
+
+            if compat:
+                for row in range(size):
+                    qr_line = ""
+                    for col in range(size):
+                        qr_line += "██" if matrix[row][col] else "  "
+                    qr_data.append(qr_line)
+                self.qr_size = size * 2
+            else:
+                for row in range(0, size, 2):
+                    qr_line = ""
+                    for line in range(size):
+                        qr_line += _modern_chars[
+                            (
+                                matrix[row][line],
+                                matrix[row + 1][line] if row + 1 < size else False,
+                            )
+                        ]
+                    qr_data.append(qr_line)
+                self.qr_size = len(qr_data) * 2
+
             self.qr_text = "\n".join(qr_data)
         except Exception as e:
             self.qr_size = 0
-            self.qr_text = f"[二维码生成失败]\n" + str(e) + "\n" + "\n".join(qr_data)
+            self.qr_text = "[二维码生成失败]\n" + str(e) + "\n" + "\n".join(qr_data)
 
     def on_resize(self):
         """窗口大小改变时重新检查"""

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -9,8 +9,6 @@ from .constants import (
     BASE_DIR,
     CONFIG_FILE,
     README_FILE,
-    QR_IMG,
-    QR_FACE_IMG,
     APP_KEY,
     APP_SECRET,
     LIVEHIME_BUILD,
@@ -25,7 +23,7 @@ from .constants import (
     Messages,
     Styles,
 )
-from .cleanup import cleanup_qr_files, cleanup_file
+from .cleanup import cleanup_file
 from .crypto import sign_api_data
 
 __all__ = [
@@ -34,8 +32,6 @@ __all__ = [
     "BASE_DIR",
     "CONFIG_FILE",
     "README_FILE",
-    "QR_IMG",
-    "QR_FACE_IMG",
     "APP_KEY",
     "APP_SECRET",
     "LIVEHIME_BUILD",
@@ -49,7 +45,6 @@ __all__ = [
     "KeyBindings",
     "Messages",
     "Styles",
-    "cleanup_qr_files",
     "cleanup_file",
     "sign_api_data",
 ]

--- a/src/utils/cleanup.py
+++ b/src/utils/cleanup.py
@@ -6,25 +6,7 @@
 import logging
 from pathlib import Path
 
-from .constants import QR_IMG, QR_FACE_IMG
-
 logger = logging.getLogger(__name__)
-
-
-def cleanup_qr_files() -> None:
-    """清理二维码图片文件
-    
-    在程序退出、登录完成或出错时调用，删除临时生成的二维码图片。
-    """
-    files_to_cleanup = [QR_IMG, QR_FACE_IMG]
-    
-    for file_path in files_to_cleanup:
-        try:
-            if file_path.exists():
-                file_path.unlink()
-                logger.debug(f"已清理文件: {file_path}")
-        except Exception as e:
-            logger.warning(f"清理文件失败 {file_path}: {e}")
 
 
 def cleanup_file(file_path: Path) -> bool:

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -8,7 +8,7 @@ from enum import Enum, auto
 from pathlib import Path
 
 # ===== 版本信息 =====
-VERSION = (0, 4, 5)
+VERSION = (0, 4, 6)
 VERSION_STR = ".".join(map(str, VERSION))
 
 # ===== 基础路径 =====

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -18,8 +18,6 @@ BASE_DIR = Path.cwd()
 # 使用工作目录下的配置文件
 CONFIG_FILE = Path("config.json")
 README_FILE = Path("使用说明.txt")
-QR_IMG = Path("qr.jpg")
-QR_FACE_IMG = Path("qr_face.jpg")
 
 # ===== B站API常量 =====
 APP_KEY: str = "aae92bc66f3edfab"

--- a/src/utils/lib.py
+++ b/src/utils/lib.py
@@ -1,0 +1,37 @@
+"""工具函数库."""
+
+from os import environ
+
+
+MODERN_ENV_VARS = [
+    "WT_SESSION",
+    "TERM_PROGRAM",
+    "TERMINAL_EMULATOR",
+    "KONSOLE_VERSION",
+    "ALACRITTY_LOG",
+    "KITTY_WINDOW_ID",
+    "VTE_VERSION",
+    "XTERM_VERSION",
+    "WEZTERM_EXECUTABLE",
+    "FOOT_META_FILE",
+    "GHOSTTY_RESOURCES_DIR",
+]
+
+MODERN_TERM_NAMES = frozenset({
+    "xterm-256color",
+    "xterm-kitty",
+    "alacritty",
+    "tmux-256color",
+    "wezterm",
+})
+
+
+def is_modern_terminal() -> bool:
+    """判断终端是否支持半块字符.
+
+    仅识别已知的现代终端 (Windows Terminal, iTerm2, Kitty 等),
+    无法识别的默认走兼容模式 (`` + 空格).
+    """
+    if any(environ.get(v) for v in MODERN_ENV_VARS):
+        return True
+    return environ.get("TERM", "") in MODERN_TERM_NAMES


### PR DESCRIPTION
为了修复该问题：#11 ，新增二维码兼容模式，确保任何终端都能显示二维码

1. 添加一个检测终端环境变量的函数，用于确认是现代终端，还是cmd这种旧终端。
2. 在显示二维码时根据终端类型，获取紧凑型二维码或兼容型二维码，并显示。
3. 显示区域过小提示正确显示。