### PR TITLE
新的二维码显示兼容方案

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bili_live_tool"
-version = "0.4.6"
+version = "0.4.7"
 description = "a simple tool to start or stop bilibili live and get stream code."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ui/screen/qr_display_screen.py
+++ b/src/ui/screen/qr_display_screen.py
@@ -6,14 +6,13 @@
 """
 
 from textual.screen import ModalScreen
-from textual.containers import Vertical
-from textual.widgets import Static
+from textual.containers import Vertical, Horizontal
+from textual.widgets import Static, Button
 from textual.reactive import reactive
 from textual.binding import Binding
 import qrcode
 
 from ...utils.constants import KeyBindings
-from ...utils.lib import is_modern_terminal
 
 
 class QRDisplayScreen(ModalScreen):
@@ -30,15 +29,29 @@ class QRDisplayScreen(ModalScreen):
         super().__init__()
         self.qr_url = qr_url
         self.title_text = title
+        self._compat = False
 
     def compose(self):
         with Vertical(id="qr-card"):
-            yield Static(self.title_text, id="qr-title")
+            with Horizontal(id="qr-header"):
+                yield Static(self.title_text, id="qr-title")
+                yield Button("切换兼容显示", id="qr-toggle-btn")
             yield Static("", id="qr-content")
             yield Static("窗口太小，请放大后查看二维码", id="qr-too-small")
 
     def on_mount(self):
         """挂载时显示二维码"""
+        self._update_display()
+
+    def on_button_pressed(self, event: Button.Pressed):
+        if event.button.id != "qr-toggle-btn":
+            return
+        self._compat = not self._compat
+        btn = event.button
+        if self._compat:
+            btn.label = "切换压缩显示"
+        else:
+            btn.label = "切换兼容显示"
         self._update_display()
 
     def _update_display(self):
@@ -55,7 +68,7 @@ class QRDisplayScreen(ModalScreen):
             qr_content = self.query_one("#qr-content", Static)
             too_small_msg = self.query_one("#qr-too-small", Static)
 
-            if getattr(self, "_compat", False):
+            if self._compat:
                 min_width = self.qr_size + 16
                 min_height = self.qr_size // 2 + 11
             else:
@@ -86,8 +99,7 @@ class QRDisplayScreen(ModalScreen):
             (False, True): "▄",
             (True, True): "█",
         }
-        compat = not is_modern_terminal()
-        self._compat = compat
+        compat = self._compat
         qr_data = []
         try:
             qr = qrcode.QRCode(

--- a/src/ui/styles/qr_display_screen.tcss
+++ b/src/ui/styles/qr_display_screen.tcss
@@ -12,11 +12,31 @@ QRDisplayScreen #qr-card {
 }
 
 QRDisplayScreen #qr-title {
+    width: 1fr;
     text-align: center;
+    content-align: center middle;
     text-style: bold;
     color: $primary;
-    margin: 1;
+    margin: 0;
     padding: 0;
+}
+
+QRDisplayScreen #qr-header {
+    height: auto;
+    margin: 1 0;
+}
+
+QRDisplayScreen #qr-toggle-btn {
+    layer: overlay;
+    dock: right;
+    width: auto;
+    background: #00a1d6;
+    color: white;
+    border: none;
+}
+
+QRDisplayScreen #qr-toggle-btn:hover {
+    background: #0089b6;
 }
 
 QRDisplayScreen #qr-content {

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -8,7 +8,7 @@ from enum import Enum, auto
 from pathlib import Path
 
 # ===== 版本信息 =====
-VERSION = (0, 4, 6)
+VERSION = (0, 4, 7)
 VERSION_STR = ".".join(map(str, VERSION))
 
 # ===== 基础路径 =====


### PR DESCRIPTION
现在不再自动检测终端，因为通过环境变量的方式不准确，比如在pyinstaller编译为exe后，环境变量缺失，但的确在现代终端中运行。

实际上，在程序内部判断一个utf-8符号是否能被正确显示几乎是不可能的，手动提供一个切换方案才是正确的方案。

现在二维码界面的右上角会显示一个按钮，用于切换二维码显示方案。